### PR TITLE
Added token_translator and STACK-2 compat

### DIFF
--- a/src/Igorw/Stack/OAuth.php
+++ b/src/Igorw/Stack/OAuth.php
@@ -35,6 +35,10 @@ class OAuth implements HttpKernelInterface
         }
 
         $request->attributes->set('oauth.token', $token);
+        $request->attributes->set(
+            'stack.authn.token',
+            $this->container['token_translator']($token)
+        );
 
         return $this->app->handle($request, $type, $catch);
     }
@@ -47,7 +51,13 @@ class OAuth implements HttpKernelInterface
         $config->process($container);
 
         foreach ($options as $name => $value) {
-            $container[$name] = $value;
+            if (in_array($name, ['token_translator'])) {
+                $container[$name] = $container->share(function () use ($value) {
+                    return $value;
+                });
+            } else {
+                $container[$name] = $value;
+            }
         }
 
         return $container;

--- a/src/Igorw/Stack/OAuth/ContainerConfig.php
+++ b/src/Igorw/Stack/OAuth/ContainerConfig.php
@@ -64,5 +64,9 @@ class ContainerConfig
         });
 
         $container['success_url'] = null;
+
+        $container['token_translator'] = $container->protect(function ($token) {
+            return $token;
+        });
     }
 }


### PR DESCRIPTION
Added a `token_translator` service. It accepts the OAuth token and returns a value that is to be treated as a STACK-2 token.

The `oauth.token` is left for BC and because it might make sense to be able to look specifically for it if you're not in an environment that cares about STACK-2. This can be changed if needed.

This is something that I'm using in stack-firewall stuff. It provides a way to translate the raw token value into something usable by the application if it is so desired.

I may still work on providing stack-firewall and/or stack-authentication integration in a bit. :)
